### PR TITLE
Add CSV export and logging window

### DIFF
--- a/lambda_explorer/__init__.py
+++ b/lambda_explorer/__init__.py
@@ -32,7 +32,23 @@ __version__ = "1.0"
 
 verboselogs.install()
 logger = verboselogs.VerboseLogger("module_logger")
-coloredlogs.install(level="CRITICAL", logger=logger)
+
+
+def setup_logging(level: str = "INFO") -> None:
+    """Configure logging for the module.
+
+    Parameters
+    ----------
+    level : str, optional
+        Logging level passed to :func:`coloredlogs.install` and used for the
+        global logger. Defaults to ``"INFO"``.
+    """
+
+    coloredlogs.install(level=level, logger=logger)
+    logger.setLevel(level)
+
+
+setup_logging()
 
 # -----------------------------------------------------------------------------
 # CLASSES

--- a/lambda_explorer/tools/__init__.py
+++ b/lambda_explorer/tools/__init__.py
@@ -32,7 +32,16 @@ __version__ = "1.0"
 
 verboselogs.install()
 logger = verboselogs.VerboseLogger("module_logger")
-coloredlogs.install(level="CRITICAL", logger=logger)
+
+
+def setup_logging(level: str = "INFO") -> None:
+    """Configure logging for this subpackage."""
+
+    coloredlogs.install(level=level, logger=logger)
+    logger.setLevel(level)
+
+
+setup_logging()
 
 # -----------------------------------------------------------------------------
 # CLASSES


### PR DESCRIPTION
## Summary
- configure module loggers with `setup_logging`
- introduce DearPyGui logger window
- allow CSV export of plotted data and annotate max value
- show logs from the main menu

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68499d85278c8327a563f420df63e550