### PR TITLE
Ensure main menu appears on launch

### DIFF
--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -436,6 +436,7 @@ def build_context_menu(width=320, height=390):
     dpg.create_viewport(title="Formula Overview", width=width, height=height)
     dpg.setup_dearpygui()
     dpg.show_viewport()
+    dpg.show_item("main_window")
     dpg.maximize_viewport()
 
     # dock windows on startup


### PR DESCRIPTION
## Summary
- show the formula overview window when starting the GUI

## Testing
- `pytest`
- `ruff check` *(fails: unused imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684af2a603588327904e9d2282ea174f