### PR TITLE
Add window layout persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ any formula window to load or save the `defaults.yaml` file directly, or choose
 "Save As" to export the defaults to a custom YAML file. The defaults map
 variable names to their stored string values.
 
+The application also remembers your window layout. When you close the GUI, the
+current positions and sizes of all windows are written to `layout.ini` and
+restored on the next start.
+
 ## Developer Documentation
 
 Developers who want to implement additional formulas can follow the guide in

--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -10,6 +10,7 @@ from .aero_formulas import ReynoldsNumber, DynamicViscosity, KinematicViscosity
 from .formula_base import Formula
 from .solver import FormulaSolver
 from .default_manager import default_values, load_defaults_file, save_defaults_file
+from .layout_manager import load_layout, save_layout, LAYOUT_FILE
 
 
 # Discover all Formula subclasses
@@ -433,6 +434,7 @@ def build_context_menu(width=320, height=390):
         dpg.add_button(label="View logs", callback=show_log_window)
     dpg.create_viewport(title="Formula Overview", width=width, height=height)
     dpg.setup_dearpygui()
+    load_layout()
     dpg.show_viewport()
     dpg.show_item("main_window")
     dpg.maximize_viewport()
@@ -451,6 +453,7 @@ def build_context_menu(width=320, height=390):
     lh = dpg.get_item_height(log_window_tag)
     dpg.set_item_width(log_window_tag, vp_w - 20)
     dpg.set_item_pos(log_window_tag, [10, vp_h - lh - 10])
+    dpg.set_exit_callback(lambda: save_layout())
     dpg.start_dearpygui()
     dpg.destroy_context()
 

--- a/lambda_explorer/tools/layout_manager.py
+++ b/lambda_explorer/tools/layout_manager.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import dearpygui.dearpygui as dpg
+
+LAYOUT_FILE = "layout.ini"
+
+
+def load_layout(path: str = LAYOUT_FILE) -> None:
+    """Load window layout from an ini file if it exists."""
+    if os.path.exists(path):
+        try:
+            dpg.load_init_file(path)
+        except Exception:
+            pass
+
+
+def save_layout(path: str = LAYOUT_FILE) -> None:
+    """Save current window layout to an ini file."""
+    try:
+        dpg.save_init_file(path)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- implement `layout_manager` to save/load `layout.ini`
- load layout on startup and save it on exit
- document new layout persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2d334f5483278c6cea16bf774c0f