### PR TITLE
Add runtime logging configuration window

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The application also remembers your window layout. When you close the GUI, the
 current positions and sizes of all windows are written to `layout.ini` and
 restored on the next start.
 
+The *Settings* window lets you adjust the logging level of the application at
+runtime. Choose between `DEBUG`, `INFO`, `WARNING` and `ERROR` to control the
+amount of information written to the log window.
+
 ## Developer Documentation
 
 Developers who want to implement additional formulas can follow the guide in

--- a/lambda_explorer/tools/default_manager.py
+++ b/lambda_explorer/tools/default_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Dict
 import yaml
 import os
+from . import logger
 
 # Global mapping of default values used across the GUI
 default_values: Dict[str, str] = {}
@@ -10,19 +11,28 @@ default_values: Dict[str, str] = {}
 
 def load_defaults_file(path: str = "defaults.yaml") -> None:
     """Load defaults from a YAML file into ``default_values``."""
+    logger.debug("Loading defaults from %s", path)
     if not os.path.exists(path):
+        logger.warning("Defaults file %s does not exist", path)
         return
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-    except OSError:
+    except OSError as exc:
+        logger.error("Failed to read defaults file %s: %s", path, exc)
         return
     if isinstance(data, dict):
         for var, val in data.items():
             default_values[var] = str(val)
+    logger.info("Loaded %d default values", len(default_values))
 
 
 def save_defaults_file(path: str = "defaults.yaml") -> None:
     """Write ``default_values`` to a YAML file."""
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(default_values, f, sort_keys=False)
+    logger.debug("Saving defaults to %s", path)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(default_values, f, sort_keys=False)
+        logger.info("Saved defaults to %s", path)
+    except OSError as exc:
+        logger.error("Failed to save defaults to %s: %s", path, exc)

--- a/lambda_explorer/tools/formula_base.py
+++ b/lambda_explorer/tools/formula_base.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Callable, Dict
 import sympy  # type: ignore
+from . import logger
+
 
 class Formula:
     """Base class for symbolic equations providing cached solvers."""
@@ -24,19 +26,29 @@ class Formula:
         self.vars = cls._vars
         self.eq = cls.eq
         self._solvers = cls._solvers
+        logger.debug("Initialized formula %s", cls.__name__)
 
     def solve(self, **knowns) -> float:
         total = set(self.vars.keys())
         given = set(knowns.keys())
         extras = given - total
         if extras:
-            raise ValueError(f"Unknown variable(s) provided: {', '.join(sorted(extras))}")
+            raise ValueError(
+                f"Unknown variable(s) provided: {', '.join(sorted(extras))}"
+            )
         expected = len(total) - 1
         if len(given) < expected:
             missing = sorted(total - given)
-            raise ValueError(f"{len(missing)} variable(s) missing: {', '.join(missing)}")
+            raise ValueError(
+                f"{len(missing)} variable(s) missing: {', '.join(missing)}"
+            )
         if len(given) > expected:
-            raise ValueError(f"Too many variables provided (expected {expected}, got {len(given)})")
+            raise ValueError(
+                f"Too many variables provided (expected {expected}, got {len(given)})"
+            )
         target = (total - given).pop()
         args = [knowns[name] for name in self.vars if name != target]
-        return float(self._solvers[target](*args))
+        logger.debug("Solving for %s with %s", target, knowns)
+        result = float(self._solvers[target](*args))
+        logger.verbose("%s result %s", target, result)
+        return result

--- a/lambda_explorer/tools/layout_manager.py
+++ b/lambda_explorer/tools/layout_manager.py
@@ -2,22 +2,27 @@ from __future__ import annotations
 
 import os
 import dearpygui.dearpygui as dpg
+from . import logger
 
 LAYOUT_FILE = "layout.ini"
 
 
 def load_layout(path: str = LAYOUT_FILE) -> None:
     """Load window layout from an ini file if it exists."""
+    logger.debug("Loading layout from %s", path)
     if os.path.exists(path):
         try:
             dpg.load_init_file(path)
-        except Exception:
-            pass
+            logger.info("Layout loaded from %s", path)
+        except Exception as exc:  # pragma: no cover - GUI
+            logger.warning("Could not load layout: %s", exc)
 
 
 def save_layout(path: str = LAYOUT_FILE) -> None:
     """Save current window layout to an ini file."""
+    logger.debug("Saving layout to %s", path)
     try:
         dpg.save_init_file(path)
-    except Exception:
-        pass
+        logger.info("Layout saved to %s", path)
+    except Exception as exc:  # pragma: no cover - GUI
+        logger.warning("Could not save layout: %s", exc)

--- a/lambda_explorer/tools/solver.py
+++ b/lambda_explorer/tools/solver.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 from typing import Dict
 
 from .formula_base import Formula
+from . import logger
+
 
 class FormulaSolver:
     """Simple wrapper around Formula providing a consistent interface."""
 
     def __init__(self, formula: Formula) -> None:
         self.formula = formula
+        logger.debug("Created solver for %s", formula.__class__.__name__)
 
     def solve(self, values: Dict[str, float]) -> float:
         """Solve formula for the unknown variable using provided values."""
-        return self.formula.solve(**values)
+        logger.debug(
+            "Solving %s with values %s", self.formula.__class__.__name__, values
+        )
+        result = self.formula.solve(**values)
+        logger.verbose("Result for %s: %s", self.formula.__class__.__name__, result)
+        return result


### PR DESCRIPTION
## Summary
- allow adjusting the log level through a new Settings window
- inject debug log statements throughout the codebase for better traceability
- document Settings window in the README

## Testing
- `black --check lambda_explorer`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3378a70083278931165121cfbe99