### PR TITLE
Add lightweight CLI and drop numpy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,23 @@ pip install -e .
 
 ## Usage
 
-After installation you can launch the application with the command:
+After installation you can launch the GUI with the command:
 
 ```bash
 lambda-explorer
 ```
 
 This will open the formula browser where you can calculate and visualize formulas.
+
+### Lightweight CLI
+
+If memory usage is a concern you can use a simple command line interface:
+
+```bash
+lambda-explorer-cli
+```
+
+This avoids the GUI and only loads the selected formula when needed.
 
 ## Library Usage
 

--- a/lambda_explorer/cli.py
+++ b/lambda_explorer/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .tools.formula_base import Formula
+from .tools.solver import FormulaSolver
+from .tools.aero_formulas import *  # Register formulas
+
+
+def run_cli() -> None:
+    """Simple command line interface for solving formulas."""
+    formulas: Dict[str, Type[Formula]] = {
+        cls.__name__: cls for cls in Formula.__subclasses__()
+    }
+    while True:
+        print("Available formulas:")
+        for name in sorted(formulas):
+            print(f"  {name}")
+        choice = input("Select formula (or 'q' to quit): ").strip()
+        if choice.lower() in {"q", "quit", "exit"}:
+            break
+        cls = formulas.get(choice)
+        if not cls:
+            print("Unknown formula\n")
+            continue
+        formula = cls()
+        solver = FormulaSolver(formula)
+        knowns: Dict[str, float] = {}
+        missing = None
+        for var in formula.variables:
+            val = input(f"{var} (leave empty to solve for this): ")
+            if not val.strip():
+                if missing is not None:
+                    print("Error: more than one variable left empty.\n")
+                    break
+                missing = var
+            else:
+                try:
+                    knowns[var] = float(val)
+                except ValueError:
+                    print(f"Invalid value for {var}\n")
+                    break
+        else:
+            try:
+                result = solver.solve(knowns)
+                print(f"{missing} = {result}\n")
+            except Exception as exc:
+                print(f"Error: {exc}\n")
+
+
+if __name__ == "__main__":
+    run_cli()
+
+

--- a/lambda_explorer/tools/formula_base.py
+++ b/lambda_explorer/tools/formula_base.py
@@ -22,7 +22,10 @@ class Formula:
                 if not sols:
                     raise ValueError(f"No solution for {target}")
                 args = [v for n, v in cls._vars.items() if n != target]
-                cls._solvers[target] = sympy.lambdify(args, sols[0], "numpy")
+                # Use Python's ``math`` module for lightweight numerical
+                # evaluation to avoid importing ``numpy`` which adds
+                # significant overhead.
+                cls._solvers[target] = sympy.lambdify(args, sols[0], "math")
         self.vars = cls._vars
         self.eq = cls.eq
         self._solvers = cls._solvers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.8"
 dependencies = [
     "dearpygui",
     "sympy",
-    "numpy",
     "coloredlogs",
     "verboselogs",
     "pyyaml"
@@ -20,6 +19,7 @@ dependencies = [
 
 [project.scripts]
 lambda-explorer = "lambda_explorer:main"
+lambda-explorer-cli = "lambda_explorer.cli:run_cli"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ dearpygui
 sympy
 coloredlogs
 verboselogs
-numpy
 pyyaml


### PR DESCRIPTION
## Summary
- avoid numpy in formula solving to reduce memory
- add simple CLI alternative
- document CLI usage and remove numpy requirement

## Testing
- `python -m compileall -q .`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_684d3802eb0c83279bfe1c89dbdc223a