### PR TITLE
Fix formula discovery and logging

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -3,8 +3,8 @@
 This project uses **SymPy** to define symbolic equations that can be solved and
 visualised inside the GUI. Each formula is implemented as a subclass of
 `lambda_explorer.tools.formula_base.Formula`. When a module defining new
-formulas is imported, they automatically appear in the GUI because the GUI looks
-at `Formula.__subclasses__()`.
+formulas is imported, they automatically appear in the GUI because the GUI
+recursively searches for subclasses of ``Formula``.
 
 ## Creating a Formula Class
 


### PR DESCRIPTION
## Summary
- recursively discover formula subclasses
- ensure ExampleIcingEquation is available
- update logging level handling
- update developer docs about formula discovery

## Testing
- `pip install -e .`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from lambda_explorer.tools.gui_tools import formula_classes
print('ExampleIcingEquation' in formula_classes)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684d593dc7a88327a0828ea1b96dd342