### PR TITLE
Fix NameError by importing log_calls

### DIFF
--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import csv
 import coloredlogs
 import dearpygui.dearpygui as dpg
-from .. import logger
+from .. import logger, log_calls
 
 # path to application icons
 ICON_PATH = Path(__file__).resolve().parent.parent / "logo" / "favicon.ico"


### PR DESCRIPTION
## Summary
- fix missing `log_calls` import in `gui_tools`

## Testing
- `pytest -q`
- `pip install -e .`
- `lambda-explorer` (fails: Segmentation fault)

------
https://chatgpt.com/codex/tasks/task_e_684e9af79c588327a00141b5c6a50c85