### PR TITLE
Fix show_log_window callback

### DIFF
--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -84,7 +84,7 @@ def setup_logger_window() -> None:  # pragma: no cover - GUI
 
 
 @log_calls
-def show_log_window(sender, app_data, user_data):  # pragma: no cover - GUI
+def show_log_window(sender=None, app_data=None, user_data=None):  # pragma: no cover - GUI
     """Display the logging window."""
     setup_logger_window()
     logger.debug("Showing log window")


### PR DESCRIPTION
## Summary
- allow `show_log_window` to be called without arguments

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_684e9d055e848327aab0f837c94c41d2