### PR TITLE
Fix callback signature handling

### DIFF
--- a/lambda_explorer/__init__.py
+++ b/lambda_explorer/__init__.py
@@ -34,6 +34,7 @@ verboselogs.install()
 logger = verboselogs.VerboseLogger("module_logger")
 
 from functools import wraps
+import inspect
 
 
 def log_calls(func: tp.Callable) -> tp.Callable:
@@ -43,6 +44,11 @@ def log_calls(func: tp.Callable) -> tp.Callable:
     def wrapper(*args, **kwargs):
         logger.verbose("Calling %s", func.__qualname__)
         return func(*args, **kwargs)
+
+    # Preserve the original function signature so frameworks relying on
+    # introspection (e.g. DearPyGui) can determine the correct callback
+    # arguments even though we wrap the function.
+    wrapper.__signature__ = inspect.signature(func)
 
     return wrapper
 


### PR DESCRIPTION
## Summary
- ensure log_calls decorator preserves wrapped function signature

## Testing
- `pip install -e .`
- `python -m compileall -q lambda_explorer build`


------
https://chatgpt.com/codex/tasks/task_e_684e9ef8b7908327b44c49e9c0d57ac0