### PR TITLE
Fix runaway plotting loop

### DIFF
--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -312,6 +312,21 @@ def plot_callback(sender, app_data, user_data):
     start = float(dpg.get_value(user_data["x_start"]))
     end = float(dpg.get_value(user_data["x_end"]))
     step = float(dpg.get_value(user_data["x_step"]))
+
+    if step <= 0:
+        logger.error("Step must be positive, got %s", step)
+        return
+
+    max_points = 10000
+    num_points = int(max(0, (end - start) / step)) + 1
+    if num_points > max_points:
+        logger.warning(
+            "Requested %d points exceeds limit of %d; truncating",
+            num_points,
+            max_points,
+        )
+        end = start + step * (max_points - 1)
+        num_points = max_points
     consts = {}
     for var, tag in user_data["const_tags"].items():
         val = dpg.get_value(tag)
@@ -322,7 +337,7 @@ def plot_callback(sender, app_data, user_data):
     xs: List[float] = []
     ys: List[float] = []
     x = start
-    while x <= end:
+    for _ in range(num_points):
         knowns = consts.copy()
         knowns[x_var] = x
         try:


### PR DESCRIPTION
## Summary
- avoid infinite loops in GUI plotting when step is zero
- warn when too many points requested and limit number of plot points

## Testing
- `pip install -e .`
- `lambda-explorer` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_684ea6404a2c83278c29520fe920f3b7