### PR TITLE
Fix Matplotlib backend initialization

### DIFF
--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import csv
 import coloredlogs
 import dearpygui.dearpygui as dpg
+import matplotlib
 from matplotlib.backends.backend_agg import FigureCanvasAgg
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 from .. import logger, log_calls


### PR DESCRIPTION
## Summary
- initialize Matplotlib with the non-GUI Agg backend

## Testing
- `pip install -e .`
- `lambda-explorer --help` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_684eab5e02fc8327a585935558555274