### PR TITLE
Fix equation rendering width

### DIFF
--- a/lambda_explorer/tools/gui_tools.py
+++ b/lambda_explorer/tools/gui_tools.py
@@ -47,8 +47,11 @@ def _get_next_pos() -> List[int]:
 
 @log_calls
 def create_latex_texture(latex: str) -> str:
-    """Render LaTeX text to a Dear PyGui texture."""
-    fig, ax = plt.subplots(figsize=(1.0, 1.0), dpi=300)
+    """Render LaTeX text to a Dear PyGui texture.
+
+    The canvas width was increased to prevent long formulas from being cut off.
+    """
+    fig, ax = plt.subplots(figsize=(3.0, 1.0), dpi=300)
     fig.patch.set_alpha(0.0)
     ax.axis("off")
     text = ax.text(0.0, 0.0, f"${latex}$", color="white", ha="left", va="bottom")


### PR DESCRIPTION
## Summary
- prevent long formulas from getting cut off by increasing the matplotlib canvas width

## Testing
- `pre-commit run --files lambda_explorer/tools/gui_tools.py`
- `lambda-explorer` *(fails: Segmentation fault)*
- `lambda-explorer-cli --help` *(manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684ebb6e87508327bde2212fcfd8b976