### PR TITLE
Fix layout persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ any formula window to load or save the `defaults.yaml` file directly, or choose
 variable names to their stored string values.
 
 The application also remembers your window layout. When you close the GUI, the
-current positions and sizes of all windows are written to `layout.ini` and
-restored on the next start.
+current positions and sizes of all windows are written to `layout.ini` and the
+list of visible windows is stored in `open_windows.json`. Both the layout and
+open windows are restored on the next start.
 
 The *Settings* window lets you adjust the logging level of the application at
 runtime. Choose between `DEBUG`, `INFO`, `WARNING` and `ERROR` to control the

--- a/lambda_explorer/tools/window_state_manager.py
+++ b/lambda_explorer/tools/window_state_manager.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from . import logger, log_calls
+
+WINDOWS_FILE = "open_windows.json"
+
+
+@log_calls
+def load_open_windows(path: str = WINDOWS_FILE) -> List[str]:
+    """Return list of formula names that were open last session."""
+    logger.debug("Loading open windows from %s", path)
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return [str(x) for x in data]
+    except Exception as exc:  # pragma: no cover - GUI
+        logger.warning("Could not load open windows: %s", exc)
+    return []
+
+
+@log_calls
+def save_open_windows(windows: List[str], path: str = WINDOWS_FILE) -> None:
+    """Store the list of open formula window names."""
+    logger.debug("Saving open windows to %s", path)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(windows, f)
+        logger.info("Saved open windows to %s", path)
+    except Exception as exc:  # pragma: no cover - GUI
+        logger.warning("Could not save open windows: %s", exc)


### PR DESCRIPTION
## Summary
- save and restore list of open windows
- restore windows before applying layout
- persist open window state on exit
- document restoration in README

## Testing
- `make install`
- `make lint` *(fails: pre-commit not installed)*
- `lambda-explorer` *(fails: segmentation fault in headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_684eef158b00832794c14c2be02bbb31