### PR TITLE
Add concise module overviews

### DIFF
--- a/lambda_explorer/__init__.py
+++ b/lambda_explorer/__init__.py
@@ -1,8 +1,7 @@
 # !/usr/bin/env python
-"""Title.
+"""Lambda Explorer package.
 
-Description
-"""
+Provides CLI entry points and GUI helpers for interactive formula exploration."""
 # -----------------------------------------------------------------------------
 # IMPORTS
 # -----------------------------------------------------------------------------

--- a/lambda_explorer/formulas/propulsion.py
+++ b/lambda_explorer/formulas/propulsion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sympy  # type: ignore
 
 from ..tools.formula_base import Formula
+"""Formulas describing fundamental rocket propulsion relations."""
 
 class GeneralThrust(Formula):
     """F = m_dot * c_e = ∮ p dA_l"""

--- a/lambda_explorer/formulas/thermodynamics.py
+++ b/lambda_explorer/formulas/thermodynamics.py
@@ -4,6 +4,8 @@ import sympy  # type: ignore
 
 from ..tools.formula_base import Formula
 
+"""Collection of thermodynamic formula classes."""
+
 # ----------------------------------------------------------------------------
 # Thermodynamic Fundamentals
 # ----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lambda-explorer"
-version = "0.1.2"
+version = "0.1.3"
 authors = [{name = "Noel Ernsting Luz"}]
 description = "GUI tool for exploring formulas using DearPyGui"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- improve module description in `__init__`
- add overview docstrings for propulsion and thermodynamics formulas
- bump version to 0.1.3

## Testing
- `pip install -e .`
- `lambda-explorer --help`
- `python -m py_compile lambda_explorer/formulas/propulsion.py lambda_explorer/formulas/thermodynamics.py lambda_explorer/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6878bd027ec8832787a47be316c22145